### PR TITLE
Fix address contract check

### DIFF
--- a/scripts/lqty.py
+++ b/scripts/lqty.py
@@ -73,11 +73,11 @@ def get_lqty_addresses(addresses, start_block, snapshot_block):
 
     addresses = set(addresses)
     new_addresses = set()
-    latest = chain[-1].number
-    for height in range(start_block, latest+1, 10000):
-        print(f"{height}/{latest}")
+    end = snapshot_block
+    for height in range(start_block, end+1, 10000):
+        print(f"{height}/{end}")
 
-        f = lambda: lqty.events.Transfer().getLogs(fromBlock=height, toBlock=min(height+10000, latest))
+        f = lambda: lqty.events.Transfer().getLogs(fromBlock=height, toBlock=min(height+10000-1, end))
         logs = brownie_retry(f)
         for i in logs:
             if i.args.value == 0:
@@ -105,7 +105,7 @@ def get_lqty_addresses(addresses, start_block, snapshot_block):
                 addresses.add(addr)
 
     print(f"\nFound {len(addresses)} addresses!")
-    return sorted(addresses), latest
+    return sorted(addresses), end
 
 
 def get_block_at_timestamp(timestamp):


### PR DESCRIPTION
have identified an issue when using `addresses.json` cache: a contract address is included in the JSON file, which has 1 wei LQTY and counted towards airdrop distribution.

root cause is when fetching transfer addresses, the script scans through all blocks until latest, but when later check if it's a contract, a snapshot block is provided. therefore a contract created **after** the snapshot block will be recognized as EOA and stored into the JSON file.

fix is simple: only scan for LQTY transfer until the snapshot block.

also a minor fix on `getLogs` range  (`toBlock`) as it's inclusive.